### PR TITLE
mac zsh not valid identifier issues with aliases

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -22,7 +22,7 @@ function cmd {
  fi
 }
 # Alias
-_:(){ cmd "$@"; }
+_(){ cmd "$@"; }
 
 function ctrl_c(){
   export trappedCtrlC=1
@@ -163,4 +163,4 @@ function _ask {
  echo;
 }
 # Alias
-_?() { _ask "$@"; }
+_q() { _ask "$@"; }

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,23 @@
+source format.sh
+
+__ "Hello World" 1
+
+__ "Hello World" 2
+
+__ "Hello World" 3
+
+__ "Hello World" 4
+
+__ "Hello World" 5
+
+__ "Hello World" 6
+
+___ "Press any key to continue to advanced formatting examples..."
+
+__ "Gathering user input" 2
+_q "Enter your name" USER_NAME "Guest"
+__ "Hello, $USER_NAME!" 5
+
+cmd "ls -al"
+
+oo 5 "ls | wc -l"


### PR DESCRIPTION
As zsh is the default shell on macos, if I didn't change to bash, I would receive the following errors.

Before change errors: 
```
geoallen@geoallen-mac format % ./test.sh 
format.sh: line 25: `_:': not a valid identifier
geoallen@geoallen-mac format % ./test.sh
format.sh: line 166: `_?': not a valid identifier
geoallen@geoallen-mac format % ./test.sh
```

After removing the : and ? in the Aliases, it work as expected.  You'll see I just removed the : and replace the ? with q, but basically those characters do not seem valid for zsh identifiers.

zsh --version
zsh 5.9 (x86_64-apple-darwin23.0)


